### PR TITLE
added nrepl endpoint with auth support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -53,7 +53,8 @@
                  [com.github.fractl-io/fractl-config-secrets-reader "0.1.0"]
                  [nrepl "1.1.1"]
                  [camel-snake-kebab "0.4.3"]
-                 [stringer "0.4.1"]]
+                 [stringer "0.4.1"]
+                 [nrepl/drawbridge "0.2.1"]]
 
   :license {:name "Apache2"}
 

--- a/src/agentlang/core.clj
+++ b/src/agentlang/core.clj
@@ -139,10 +139,11 @@
   ([script-names options]
    (let [options (if (ur/config-data-key options)
                    options
-                   (second (ur/merge-options-with-config options)))
-         model-info (ur/read-model-and-config script-names options)]
-     (run-service script-names
-                  model-info)))
+                   (second (ur/merge-options-with-config options)))]
+     (run-service
+      script-names
+      (ur/read-model-and-config script-names options)
+      nil)))
   ([script-names]
    (run-script script-names {:config "config.edn"})))
 

--- a/src/agentlang/core.clj
+++ b/src/agentlang/core.clj
@@ -140,14 +140,9 @@
    (let [options (if (ur/config-data-key options)
                    options
                    (second (ur/merge-options-with-config options)))
-         model-info (ur/read-model-and-config script-names options)
-         model-name (:name (ffirst model-info))
-         lower-model-name (s/lower-case (name model-name))]
+         model-info (ur/read-model-and-config script-names options)]
      (run-service script-names
-                  model-info
-                   ;; this is problematic, agentlang-nrepl-handler relies on loaded model but it leads to error:
-                  ;;  model not found in any of ["/Users/macbook/code/fractl/agentlang/agentlang/test/sample/"]
-                  (agentlang-nrepl-handler model-name options))))
+                  model-info)))
   ([script-names]
    (run-script script-names {:config "config.edn"})))
 

--- a/src/agentlang/http.clj
+++ b/src/agentlang/http.clj
@@ -1335,12 +1335,10 @@
          [auth _ :as auth-info] (make-auth-handler config)
          app-config (gs/get-app-config)
          graphql-enabled (get-in app-config [:graphql :enabled] true)
-         nrepl-env-enabled (some-> (System/getenv "NREPL_ENDPOINT_ENABLED")
-                                   Boolean/parseBoolean)
+         nrepl-env-value (System/getenv "NREPL_ENDPOINT_ENABLED")
          nrepl-config-enabled (get-in app-config [:nrepl :enabled] false)
-         nrepl-enabled (if (some? nrepl-env-enabled)
-                         ;; env value should override config
-                         nrepl-env-enabled
+         nrepl-enabled (if (some? nrepl-env-value)
+                         (Boolean/parseBoolean nrepl-env-value)
                          nrepl-config-enabled)]
 
      (when graphql-enabled

--- a/src/agentlang/http.clj
+++ b/src/agentlang/http.clj
@@ -1313,7 +1313,7 @@
    :preview-magiclink        (partial process-preview-magiclink auth-info)
    :meta                     (partial process-meta-request auth-info)})
 
-(defn- start-http-server [evaluator config auth auth-info contains-graph-map nrepl-enabled nrepl-handler]
+(defn- start-http-server [evaluator config auth auth-info nrepl-enabled nrepl-handler]
   (if (or (not auth) (auth-service-supported? auth))
     (let [config (merge {:port 8080 :thread (+ 1 (u/n-cpu))} config)]
       (println (str "The HTTP server is listening on port " (:port config)))
@@ -1322,11 +1322,10 @@
           config auth
           (merge
             (create-route-handlers evaluator auth auth-info config)
-            (when nrepl-enabled
+            (when (and nrepl-handler nrepl-enabled)
               {:nrepl (partial nrepl-http-handler auth-info nrepl-handler)})))
         config))
     (u/throw-ex (str "authentication service not supported - " (:service auth)))))
-
 
 (defn run-server
   ([evaluator config nrepl-handler]
@@ -1340,7 +1339,6 @@
 
      (when graphql-enabled
        (generate-graphql-schema core-component-name schema contains-graph-map))
-
-     (start-http-server evaluator config auth auth-info contains-graph-map nrepl-enabled nrepl-handler)))
+     (start-http-server evaluator config auth auth-info nrepl-enabled nrepl-handler)))
   ([evaluator nrepl-handler]
    (run-server evaluator {} nrepl-handler)))

--- a/src/agentlang/lang/tools/nrepl/core.clj
+++ b/src/agentlang/lang/tools/nrepl/core.clj
@@ -24,7 +24,7 @@
       (replcmds/switch cn))
     (partial repl/repl-eval store (atom nil) evaluator)))
 
-(defn init-repl-eval-func [model-name options]
+(defn init-nrepl-eval-func [model-name options]
   (ur/force-call-after-load-model
     model-name
     (fn []

--- a/src/agentlang/util/http.cljc
+++ b/src/agentlang/util/http.cljc
@@ -39,6 +39,7 @@
 
 (def entity-event-prefix "/api/")
 (def graphql-prefix "/graphql")
+(def nrepl-prefix "/nrepl")
 (def login-prefix "/login")
 (def logout-prefix "/logout")
 (def signup-prefix "/signup")


### PR DESCRIPTION
PR supports accessing nREPL functionality over HTTP endpoint `/nrepl` - authentication will be applicable same as other endpoints. nREPL endpoint isn't available by default and can be enabled through config:

```
{:service {:port 8080}
 :nrepl {:enabled true}}
```