### PR TITLE
Add logger in nREPL and send cleaner response

### DIFF
--- a/src/agentlang/evaluator.cljc
+++ b/src/agentlang/evaluator.cljc
@@ -547,9 +547,13 @@
    (defn async-evaluate-pattern [pat result-chan]
      (async/go
        (try
-        (async/>! result-chan (evaluate-pattern pat))
-        (catch Exception e
-          (async/>! result-chan
-                    (str "Error during evaluation:"
-                         (.getMessage e)))))
+         (let [evaluation-result (evaluate-pattern pat)]
+           (log/info (str "Evaluation result from async-evaluate-pattern is: " evaluation-result))
+           (async/>! result-chan evaluation-result))
+         (catch Exception e
+           (do
+             (log/warn (str "Exception during evaluation on async-evaluate-pattern: " (.getMessage e)))
+             (async/>! result-chan
+                       (str "Error during evaluation:"
+                            (.getMessage e))))))
        (async/close! result-chan))))


### PR DESCRIPTION
Changes:
* Add logger support for nREPL request and evaluation
* Update response from nREPL simplflying it and removing env keys with tags which cljs reader cannot read