### PR TITLE
exact type for parent attribute is needed for postgres `=` operator

### DIFF
--- a/src/agentlang/component.cljc
+++ b/src/agentlang/component.cljc
@@ -1847,7 +1847,10 @@
   ([recname recversion]
    (contain-rels true recname recversion)))
 
-(def parent-identity-attribute-type (constantly :Any))
+(defn parent-identity-attribute-type [parent-recname]
+  (when-let [a (or (path-identity-attribute-name parent-recname)
+                   (identity-attribute-name parent-recname))]
+    (attribute-type parent-recname a)))
 
 (defn parent-of? [child parent]
   (let [child (li/make-path child)

--- a/test/agentlang/test/features05.cljc
+++ b/test/agentlang/test/features05.cljc
@@ -356,7 +356,7 @@
                 {:Npid/B {:Id 102 :No 24}}
                 li/path-attr "/A/1/AB/"}})]
       (is (b? b2))
-      (is (= "1" (li/parent-attr b2))))))
+      (is (= 1 (li/parent-attr b2))))))
 
 (deftest issue-1377-pattern-doc
   (defcomponent :I1377


### PR DESCRIPTION
fixes agentlang.test.features05/views-on-contains for postgres