### PR TITLE
Migration enhancements: renaming tables & git support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -56,7 +56,8 @@
                  [nrepl "1.1.1"]
                  [camel-snake-kebab "0.4.3"]
                  [stringer "0.4.1"]
-                 [nrepl/drawbridge "0.2.1"]]
+                 [nrepl/drawbridge "0.2.1"]
+                 [clj-jgit "1.0.2"]]
 
   :license {:name "Apache2"}
 

--- a/src/agentlang/component.cljc
+++ b/src/agentlang/component.cljc
@@ -1154,6 +1154,17 @@
        result)))
   ([component] (entity-names component true)))
 
+(defn all-entity-names-and-versions []
+  (reduce
+   (fn [entities c]
+     (merge
+      entities
+      (apply
+       merge
+       (map #(do {% (get-model-version c)})
+            (entity-names c false)))))
+   {} (component-names)))
+
 (def event-names (partial record-names-by-type :event))
 
 (defn relationship-names [component]

--- a/src/agentlang/core.clj
+++ b/src/agentlang/core.clj
@@ -298,17 +298,18 @@
                                                     (ur/read-model-and-config options)
                                                     (agentlang-nrepl-handler (first %) options))))
                   :migrate           (fn [args]
-                                       (if (and (= 3 (count args))
-                                                (contains? #{"git" "local"} (second args)))
-                                         (ur/call-after-load-model-migrate
-                                          (first args) (second args) (last args) options
-                                          (fn []
-                                            (run-migrations
-                                             (ur/read-model-and-config options)
-                                             (agentlang-nrepl-handler (first args) options))))
-                                         (do
-                                           (println "Correct usage:\n")
-                                           (print-help))))
+                                       (let [args (if (= 3 (count args)) args (cons nil args))]
+                                         (if (and (= 3 (count args))
+                                                  (contains? #{"git" "local"} (second args)))
+                                           (ur/call-after-load-model-migrate
+                                            (first args) (second args) (last args) options
+                                            (fn []
+                                              (run-migrations
+                                               (ur/read-model-and-config options)
+                                               (agentlang-nrepl-handler (first args) options))))
+                                           (do
+                                             (println "Correct usage:\n")
+                                             (print-help)))))
                   :compile           #(println (build/compile-model (first %)))
                   :build             #(println (build/standalone-package (first %)))
                   :install           #(println (build/install-model nil (first %)))

--- a/src/agentlang/core.clj
+++ b/src/agentlang/core.clj
@@ -50,21 +50,6 @@
        (h/run-server evaluator server-cfg nrepl-handler))))
   ([model-info nrepl-handler] (run-service nil model-info nrepl-handler)))
 
-(defn run-migrations
-  [model-info _]
-  (let [[[_ _] config] (ur/prepare-runtime nil model-info)]
-    (when-let [server-cfg (ur/make-server-config config)]
-      (try
-        (let
-         [r (ev/eval-all-dataflows
-             (cn/make-instance
-              {:Agentlang.Kernel.Lang/Migrations {}}))]
-          (log/info (str "migrations result: " r))
-          r)
-        (catch Exception ex
-          (log/error (str "migrations event failed: " (.getMessage ex)))
-          (log/error ex)))
-      (log/info (str "Migrations config - " server-cfg)))))
 
 (defn generate-swagger-doc [model-name args]
   (let [model-path (first args)]
@@ -302,11 +287,7 @@
                                          (if (and (= 3 (count args))
                                                   (contains? #{"git" "local"} (second args)))
                                            (ur/call-after-load-model-migrate
-                                            (first args) (second args) (last args) options
-                                            (fn []
-                                              (run-migrations
-                                               (ur/read-model-and-config options)
-                                               (agentlang-nrepl-handler (first args) options))))
+                                            (first args) (second args) (last args) options)
                                            (do
                                              (println "Correct usage:\n")
                                              (print-help)))))

--- a/src/agentlang/core.clj
+++ b/src/agentlang/core.clj
@@ -229,13 +229,14 @@
   (println "  publish MODEL-NAME TARGET  Publish the model to the target - local, clojars or github")
   (println "  exec MODEL-NAME            Build and run the model as a standalone application")
   (println "  repl MODEL-NAME            Launch the Agentlang REPL")
+  (println "  migrate MODEL-NAME [git/local] [branch/path]          Migrate database given previous version of the app")
   (println)
   (println "The model will be searched in the local directory or under the paths pointed-to by")
   (println "the `AGENTLANG_MODEL_PATHS` environment variable. If `MODEL-NAME` is not provided,")
   (println "the agentlang command will try to load a model available in the current directory.")
   (println)
   (println "The command-line arguments accepted by agentlang are:")
-  (println "  -c --config CONFIG          Configuration file")
+  (println "  -c --config CONFIG         Configuration file")
   (println "  -s --doc MODEL             Generate HTML documentation")
   (println "  -i --interactive 'desc'    Use AI to generate a model from the textual description")
   (println "  -h --help                  Print this help and quit")
@@ -296,11 +297,18 @@
                                                    (run-service
                                                     (ur/read-model-and-config options)
                                                     (agentlang-nrepl-handler (first %) options))))
-                  :custom:migrate    #(ur/call-after-load-model-migrate
-                                       (first %) (fn []
-                                                   (run-migrations
-                                                    (ur/read-model-and-config options)
-                                                    (agentlang-nrepl-handler (first %) options))))
+                  :migrate           (fn [args]
+                                       (if (and (= 3 (count args))
+                                                (contains? #{"git" "local"} (second args)))
+                                         (ur/call-after-load-model-migrate
+                                          (first args) (second args) (last args) options
+                                          (fn []
+                                            (run-migrations
+                                             (ur/read-model-and-config options)
+                                             (agentlang-nrepl-handler (first args) options))))
+                                         (do
+                                           (println "Correct usage:\n")
+                                           (print-help))))
                   :compile           #(println (build/compile-model (first %)))
                   :build             #(println (build/standalone-package (first %)))
                   :install           #(println (build/install-model nil (first %)))

--- a/src/agentlang/lang/tools/loader.cljc
+++ b/src/agentlang/lang/tools/loader.cljc
@@ -226,7 +226,7 @@
          (catch Exception ex
            (.printStackTrace ex))))
 
-     (defn- verified-model-file-path
+     (defn verified-model-file-path
        ([model-script-name root-dir model-dir]
         (let [p (str root-dir u/path-sep
                      (when model-dir

--- a/src/agentlang/store/db_common.cljc
+++ b/src/agentlang/store/db_common.cljc
@@ -144,6 +144,11 @@
     db-schema-name
     (u/throw-ex (str "Failed to create schema - " db-schema-name))))
 
+(defn rename-db-table! [connection db-table-name-new db-table-name-old]
+  (if (execute-sql! connection [(stu/rename-table-sql db-table-name-new db-table-name-old)])
+    db-table-name-new
+    (u/throw-ex (str "Failed to rename table - " db-table-name-old " to " db-table-name-new))))
+
 (defn- drop-db-schema! [connection db-schema-name]
   (if (execute-sql! connection [(stu/drop-schema-sql db-schema-name)])
     db-schema-name

--- a/src/agentlang/store/util.cljc
+++ b/src/agentlang/store/util.cljc
@@ -89,6 +89,9 @@
   (str (if unique? create-unique-index-prefix create-index-prefix)
        " " (index-name table-name) " ON " table-name "(" colname ")"))
 
+(defn rename-table-sql [to from]
+  (str "ALTER TABLE " from " RENAME TO " to))
+
 (defn create-schema-sql [schema-name]
   (str "CREATE SCHEMA IF NOT EXISTS " schema-name))
 

--- a/test/sample/migrations/11-auto-migrate-entities/factory.al
+++ b/test/sample/migrations/11-auto-migrate-entities/factory.al
@@ -1,0 +1,19 @@
+(component :Factory)
+
+(entity
+ :Customer1
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+
+(entity
+ :Customer2
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+
+(entity
+ :Customer3
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})

--- a/test/sample/migrations/11-auto-migrate-entities/model.al
+++ b/test/sample/migrations/11-auto-migrate-entities/model.al
@@ -1,0 +1,7 @@
+; to test:
+; 1. automigration/table rename
+
+{:name :Factory
+ :version "0.2.4"
+ :agentlang-version "current"
+ :components [:Factory :Office :Retail]}

--- a/test/sample/migrations/11-auto-migrate-entities/office.al
+++ b/test/sample/migrations/11-auto-migrate-entities/office.al
@@ -1,0 +1,12 @@
+(component :Office)
+
+(entity
+ :Person
+ {:Id {:type :Int :guid true}
+  :Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+
+(relationship
+ :OfficeRel
+ {:meta {:between [:Person :Person :as [:Manager :Reportee]]}})

--- a/test/sample/migrations/11-auto-migrate-entities/old/factory/factory.al
+++ b/test/sample/migrations/11-auto-migrate-entities/old/factory/factory.al
@@ -1,0 +1,32 @@
+(component :Factory)
+
+(entity
+ :Customer1
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+
+(entity
+ :Customer2
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+
+(entity
+ :Customer3
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+
+(dataflow
+ :Init
+ {:Factory/Customer1 {:Name "Dan Smith" :Age 34 :Gender "M"}}
+ {:Factory/Customer1 {:Name "Anna Brad" :Age 28 :Gender "F"}}
+ {:Factory/Customer2 {:Name "John Jones" :Age 45 :Gender "M"}}
+ {:Factory/Customer2 {:Name "Elizabeth Li" :Age 39 :Gender "F"}}
+ {:Factory/Customer3 {:Name "Sam Brown" :Age 31 :Gender "M"}}
+ {:Retail/User {:Name "Dan Smith" :Age 34 :Gender "M"}}
+ {:Retail/User {:Name "Anna Brad" :Age 28 :Gender "F"}}
+ {:Office/Person {:Id 10 :Name "Dan Smith" :Age 34 :Gender "M"}}
+ {:Office/Person {:Id 15 :Name "Anna Brad" :Age 28 :Gender "F"}}
+ {:Office/OfficeRel {:Manager 10 :Reportee 15}})

--- a/test/sample/migrations/11-auto-migrate-entities/old/factory/model.al
+++ b/test/sample/migrations/11-auto-migrate-entities/old/factory/model.al
@@ -1,0 +1,4 @@
+{:name :Factory
+ :version "0.2.3"
+ :agentlang-version "current"
+ :components [:Factory :Office :Retail]}

--- a/test/sample/migrations/11-auto-migrate-entities/old/factory/office.al
+++ b/test/sample/migrations/11-auto-migrate-entities/old/factory/office.al
@@ -1,0 +1,12 @@
+(component :Office)
+
+(entity
+ :Person
+ {:Id {:type :Int :guid true}
+  :Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+
+(relationship
+ :OfficeRel
+ {:meta {:between [:Person :Person :as [:Manager :Reportee]]}})

--- a/test/sample/migrations/11-auto-migrate-entities/old/factory/retail.al
+++ b/test/sample/migrations/11-auto-migrate-entities/old/factory/retail.al
@@ -1,0 +1,8 @@
+(component :Retail)
+
+(entity
+ :User
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+

--- a/test/sample/migrations/11-auto-migrate-entities/retail.al
+++ b/test/sample/migrations/11-auto-migrate-entities/retail.al
@@ -1,0 +1,8 @@
+(component :Retail)
+
+(entity
+ :User
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+

--- a/test/sample/migrations/12-auto-migrate-with-dependencies/factory/factory.al
+++ b/test/sample/migrations/12-auto-migrate-with-dependencies/factory/factory.al
@@ -1,0 +1,7 @@
+(component :Factory)
+
+(entity
+ :Customer
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})

--- a/test/sample/migrations/12-auto-migrate-with-dependencies/factory/model.al
+++ b/test/sample/migrations/12-auto-migrate-with-dependencies/factory/model.al
@@ -1,0 +1,10 @@
+; to test:
+; 1. normal entity migration, no schema change
+; 2. entity name change
+; 3. selectively migrate some data
+
+{:name :Factory
+ :version "0.3.4"
+ :agentlang-version "current" 
+ :dependencies [:Office]
+ :components [:Factory]}

--- a/test/sample/migrations/12-auto-migrate-with-dependencies/factory/old/factory/factory.al
+++ b/test/sample/migrations/12-auto-migrate-with-dependencies/factory/old/factory/factory.al
@@ -1,0 +1,17 @@
+(component :Factory)
+
+(entity
+ :Customer
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})
+
+(dataflow
+ :Init
+ {:Factory/Customer {:Name "Dan Smith" :Age 34 :Gender "M"}}
+ {:Factory/Customer {:Name "Anna Brad" :Age 28 :Gender "F"}}
+ {:Factory/Customer {:Name "John Jones" :Age 45 :Gender "M"}}
+ {:Factory/Customer {:Name "Elizabeth Li" :Age 39 :Gender "F"}}
+ {:Factory/Customer {:Name "Sam Brown" :Age 31 :Gender "M"}}
+ {:Office/Worker {:Name "Sam Brown" :Age 31 :Gender "M"}}
+ {:Office/Worker {:Name "John Jones" :Age 45 :Gender "M"}})

--- a/test/sample/migrations/12-auto-migrate-with-dependencies/factory/old/factory/model.al
+++ b/test/sample/migrations/12-auto-migrate-with-dependencies/factory/old/factory/model.al
@@ -1,0 +1,5 @@
+{:name :Factory
+ :version "0.3.3"
+ :agentlang-version "current"
+ :dependencies [:Office]
+ :components [:Factory]}

--- a/test/sample/migrations/12-auto-migrate-with-dependencies/office/model.al
+++ b/test/sample/migrations/12-auto-migrate-with-dependencies/office/model.al
@@ -1,0 +1,4 @@
+{:name :Office
+ :version "0.0.3"
+ :agentlang-version "current"
+ :components [:Office]}

--- a/test/sample/migrations/12-auto-migrate-with-dependencies/office/office.al
+++ b/test/sample/migrations/12-auto-migrate-with-dependencies/office/office.al
@@ -1,0 +1,7 @@
+(component :Office)
+
+(entity
+ :Worker
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})

--- a/test/sample/migrations/12-auto-migrate-with-dependencies/office/old/office/model.al
+++ b/test/sample/migrations/12-auto-migrate-with-dependencies/office/old/office/model.al
@@ -1,0 +1,4 @@
+{:name :Office
+ :version "0.0.2"
+ :agentlang-version "current"
+ :components [:Office]}

--- a/test/sample/migrations/12-auto-migrate-with-dependencies/office/old/office/office.al
+++ b/test/sample/migrations/12-auto-migrate-with-dependencies/office/old/office/office.al
@@ -1,0 +1,7 @@
+(component :Office)
+
+(entity
+ :Worker
+ {:Name :String
+  :Age :Int
+  :Gender {:oneof ["M" "F"]}})


### PR DESCRIPTION
Enhancements:
- user can now specify either a local path or git for migration flow to fetch old schema
- all entities are automatically migrated unless explicitly specified in config.edn `:no-auto-migration`

Example:
```
:no-auto-migration #{:Factory.Core/Customer
                      :Agentlang.Kernel.Lang
                      :SomeDependencyModel} 
```
One can specify either an entity or a component or entire (dependency) model to exclude.