### PR TITLE
Improvements in docs CLI syntax

### DIFF
--- a/src/agentlang/component.cljc
+++ b/src/agentlang/component.cljc
@@ -30,7 +30,8 @@
     :raw
     :-*-containers-*-
     :Agentlang.Kernel.UserApp
-    :Agentlang.Kernel.Repl})
+    :Agentlang.Kernel.Repl
+    :Agentlang.Kernel.Eval})
 
 (def non-instance-user-attr-keys
   #{type-tag-key id-attr type-key dirty-key})

--- a/src/agentlang/util/http.cljc
+++ b/src/agentlang/util/http.cljc
@@ -219,7 +219,7 @@
       (let [parent-entity
             (cn/containing-parents (or (first path) entity))]
         (if (empty? parent-entity)
-          {:path (str "_e/" (namespace entity)
+          {:path (str "api/" (namespace entity)
                       (when (seq path)
                         (let [path (add-path-vars path)]
                           (str "/"


### PR DESCRIPTION
- Previous syntax was: `agent --doc model-name`. Current syntax is: `agent doc model-name` or just `agent doc` in the model.
- API path fix 