### PR TITLE
automatic input events

### DIFF
--- a/example/agents/expense/expense/workflow.al
+++ b/example/agents/expense/expense/workflow.al
@@ -21,14 +21,11 @@
   :Input :Expense.Workflow/ReceiptImageToExpenseReport
   :LLM :llm01}}
 
-(event :ConvertReportToExpenses {:UserInstruction :String})
-
 {:Agentlang.Core/Agent
- {:Name :report-to-expense-agent
+ {:Name :convert-report-to-expense-agent
   :Type :planner
   :UserInstruction "Convert an expense report to individual instances of the expense entity."
-  :Tools [:Expense.Workflow/Expense]
-  :Input :Expense.Workflow/ConvertReportToExpenses}}
+  :Tools [:Expense.Workflow/Expense]}}
 
 {:Agentlang.Core/Agent
  {:Name :expense-agent
@@ -37,7 +34,7 @@
   :UserInstruction (str "1. Extract an expense report from the given receipt image url.\n"
                         "2. Convert this report to individual expenses.")
   :Input :Expense.Workflow/SaveExpenses
-  :Delegates [:receipt-ocr-agent :report-to-expense-agent]}}
+  :Delegates [:receipt-ocr-agent :convert-report-to-expense-agent]}}
 
 ;; Usage:
 ;; POST api/Expense.Workflow/SaveExpenses

--- a/src/agentlang/lang.cljc
+++ b/src/agentlang/lang.cljc
@@ -530,7 +530,7 @@
   ([schema]
    (parse-and-define record schema)))
 
-(defn- event-internal
+(defn event-internal
   ([n attrs verify-name?]
    (let [cn (if verify-name?
               (validated-canonical-type-name n)

--- a/src/agentlang/lang/raw.cljc
+++ b/src/agentlang/lang/raw.cljc
@@ -171,11 +171,11 @@
 (defn delete-definition [component-name varname]
   (remove-from-component component-name (partial clj-def? varname)))
 
-(defn- find-def [component-name varname]
+(defn- find-def-expr [component-name varname]
   (first (find-in-component component-name (partial clj-def? varname))))
 
 (defn get-definition-expr [component-name varname]
-  (nth (find-def component-name varname) 2))
+  (nth (find-def-expr component-name varname) 2))
 
 (defn update-component-spec! [component-name spec-key spec]
   (when-let [cdef (get @raw-store component-name)]


### PR DESCRIPTION
No explicit `:Input` attribute required for agents. The input-event will be auto-generated by the runtime.