### PR TITLE
respond with a map

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -50,7 +50,7 @@ export function startServer(appSpec: ApplicationSpec, port: number) {
   const appVersion: string = appSpec.version;
 
   app.get('/', (req: Request, res: Response) => {
-    res.send(appName);
+    res.send({ agentlang: { application: `${appName}@${appVersion}` } });
   });
 
   getAllEventNames().forEach((eventNames: string[], moduleName: string) => {


### PR DESCRIPTION
fixes #172 

Response example:

```
{
    "agentlang": {
        "application": "Blog@0.0.1"
    }
}
```