### PR TITLE
fix in local imports

### DIFF
--- a/src/runtime/jsmodules.ts
+++ b/src/runtime/jsmodules.ts
@@ -17,7 +17,7 @@ export async function importModule(path: string, name: string, moduleFileName?: 
     }
     path = `${s}${sep}${path}`;
   }
-  if (!(path.startsWith(sep) || path.startsWith('.'))) {
+  if ((path.startsWith(sep) || path.startsWith('.')) && moduleFileName) {
     path = process.cwd() + sep + path;
   }
   const m = await import(/* @vite-ignore */ path);


### PR DESCRIPTION
Without this fix, local imports when running Agentlang CLI in another directory are failing.

### Example ###
Import: 
```
import "resolvers/cognito.js" @as cognitoMod
```

Run command:
```
muazzam@Muazzams-MacBook-Pro deployment-service % ~/agentlang-ai/agentlang-new/bin/cli.js run .
```

### Error ###
It tries to find cognito.js in Agentlang's path, not local path:
```
.
.
    at importModule (file:///Users/muazzam/agentlang-ai/agentlang-new/out/runtime/jsmodules.js:21:15) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/muazzam/agentlang-ai/agentlang-new/out/runtime/resolvers/cognito.js'
}
```

