### PR TITLE
`/meta` endpoint to list entity, relationship, event schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agentlang",
 	"description": "Please enter a brief description here",
-	"version": "0.0.40",
+	"version": "0.0.52",
 	"files": ["bin", "out", "src"],
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Lists the schemas for entities, relationships, and events in all modules.

Usage:
- Filter by modules using query parameter `?module`
- Search for all entities containing X by query parameter `?entity=X` (case insensitive)
- Search for all events containing X by query parameter `?event=Y` 
- `entity` and `event` parameters are mutually exclusive, when you search for events no entities will be returned and vice versa