### PR TITLE
Direct between endpoints

### DIFF
--- a/example/blog/src/blog.al
+++ b/example/blog/src/blog.al
@@ -1,15 +1,5 @@
 module Blog.Core
 
-entity A {
-    id Int @id
-}
-
-entity B {
-    id Int @id
-}
-
-relationship AB between(A @as A, B @as B)
-
 entity Profile {
     id UUID @id @default(uuid()),
     address String @optional,

--- a/src/runtime/resolvers/interface.ts
+++ b/src/runtime/resolvers/interface.ts
@@ -146,19 +146,20 @@ export class Resolver {
   }
 
   /**
-   * Connect instances via a between relationship
+   * Connect/dis-connect instances via a between relationship
    * @param node1 The main node to connect
    * @param otherNodeOrNodes Nodes to be connected to node1
    * @param relEntry Details of the repationship
    */
-  public async connectInstances(
+  public async handleInstancesLink(
     node1: Instance,
     otherNodeOrNodes: Instance | Instance[],
     relEntry: Relationship,
-    orUpdate: boolean
+    orUpdate: boolean,
+    inDeleteMode: boolean
   ): Promise<any> {
     return this.notImpl(
-      `connectInstances(${node1}, ${otherNodeOrNodes}, ${relEntry}, ${orUpdate})`
+      `handleInstancesLink(${node1}, ${otherNodeOrNodes}, ${relEntry}, ${orUpdate}, ${inDeleteMode})`
     );
   }
 

--- a/src/runtime/util.ts
+++ b/src/runtime/util.ts
@@ -224,7 +224,7 @@ export const DefaultModuleName = 'agentlang';
 export const DefaultModules = new Set();
 export const DefaultFileHandlingDirectory = 'fs';
 
-export const ScratchModuleName = 'al_scratch'
+export const ScratchModuleName = 'al_scratch';
 
 export function makeCoreModuleName(n: string): string {
   return DefaultModuleName + '.' + n;


### PR DESCRIPTION
```
module acme

entity A {
    id Int @id,
    name String
}

entity B {
    id Int @id,
    K Int
}

relationship AB between(A @as A, B @as B)
```

For creating a new instance related to an existing instance - the current API is - 

```
POST acme/A/1/AB/B

{id 101, K 11}
```

For getting all `B`'s under an `A`:

```
GET acme/A/1/AB/B
```

This PR adds the following APIs:

1. Create relationship between two existing instances of `A` with `id=1` and `B` with `id=101`:

```
POST acme/AB

{"A": 1, "B": 101}
```

2. Delete a specific relationship:

```
DELETE acme/AB

{"A": 1, "B": 101}
```

Same APIs will work for `one_one` relationships.