### PR TITLE
Override app config from APP_CONFIG env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agentlang",
 	"description": "The easiest way to build the most reliable AI agents - enterprise-grade teams of AI agents that collaborate with each other and humans",
-	"version": "0.7.9",
+	"version": "0.8.0",
 	"license": "Sustainable Use License",
 	"author": "agentlang-ai",
 	"homepage": "https://github.com/agentlang-ai/agentlang#readme",

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -388,9 +388,14 @@ export async function loadAppConfig(configDir: string): Promise<Config> {
     }
   }
   try {
-    const cfg = cfgObj
+    let cfg = cfgObj
       ? await configFromObject(cfgObj)
       : await loadRawConfig(`${configDir}${path.sep}app.config.json`);
+    const envAppConfig = process.env.APP_CONFIG;
+    if (envAppConfig) {
+      const envConfig = JSON.parse(envAppConfig);
+      cfg = { ...cfg, ...envConfig };
+    }
     return setAppConfig(cfg);
   } catch (err: any) {
     if (err instanceof z.ZodError) {


### PR DESCRIPTION
`APP_CONFIG` env var (a map) can be used to override the configuration from the config.al file.